### PR TITLE
fix: harden create CLI and package metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,17 @@ node_modules/
 dist/
 .wrangler/
 .dev.vars
+.env
+.env.local
+.env.production
+.env.staging
+.mcp.json
 *.log
 .next/
 out/
 *.tsbuildinfo
 .vercel/
+.DS_Store
 packages/mcp/dist/
+.x-harness-setup.json
+.x-harness-config.json

--- a/packages/create-x-harness/package.json
+++ b/packages/create-x-harness/package.json
@@ -11,7 +11,27 @@
   ],
   "scripts": {
     "build": "tsup",
-    "dev": "tsup --watch"
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "keywords": [
+    "x",
+    "twitter",
+    "crm",
+    "harness",
+    "cloudflare",
+    "workers",
+    "mcp",
+    "ai"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Shudesu/x-harness-oss.git",
+    "directory": "packages/create-x-harness"
+  },
+  "homepage": "https://github.com/Shudesu/x-harness-oss#readme",
+  "bugs": {
+    "url": "https://github.com/Shudesu/x-harness-oss/issues"
   },
   "dependencies": {
     "@clack/prompts": "^0.9.1",
@@ -19,8 +39,12 @@
     "picocolors": "^1.1.1"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.7.0"
+  },
+  "engines": {
+    "node": ">=20"
   },
   "license": "MIT",
   "publishConfig": {

--- a/packages/create-x-harness/src/index.ts
+++ b/packages/create-x-harness/src/index.ts
@@ -1,38 +1,107 @@
-import { resolve } from "node:path";
+import { resolve, dirname, join } from "node:path";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { runSetup } from "./commands/setup.js";
 import { ensureRepo } from "./steps/clone-repo.js";
 
 const args = process.argv.slice(2);
 
-function parseArgs(): { command: string; repoDir: string | null } {
+const HELP_TEXT = `create-x-harness — set up X Harness with one command.
+
+Usage:
+  npx create-x-harness [command] [options]
+
+Commands:
+  setup    Run first-time setup (default). Clones the repo to ~/.x-harness
+           if missing, then provisions Cloudflare + X credentials.
+
+Options:
+  --repo-dir <path>    Use an existing checkout of x-harness-oss instead of
+                       cloning to ~/.x-harness.
+  -h, --help           Show this help and exit.
+  -v, -V, --version    Print the version and exit.
+
+Examples:
+  npx create-x-harness
+  npx create-x-harness --repo-dir ./my-fork
+`;
+
+function readPackageVersion(): string {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    // dist/index.js → ../package.json
+    const pkg = JSON.parse(
+      readFileSync(join(here, "..", "package.json"), "utf-8"),
+    ) as { version?: string };
+    return pkg.version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+interface ParsedArgs {
+  command: string;
+  repoDir: string | null;
+  showHelp: boolean;
+  showVersion: boolean;
+  unknownFlag: string | null;
+}
+
+function parseArgs(): ParsedArgs {
   let command = "setup";
   let repoDir: string | null = null;
+  let showHelp = false;
+  let showVersion = false;
+  let unknownFlag: string | null = null;
 
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--repo-dir" && args[i + 1]) {
+    const arg = args[i];
+    if (arg === "--repo-dir" && args[i + 1]) {
       repoDir = resolve(args[i + 1]);
       i++;
-    } else if (!args[i].startsWith("-")) {
-      command = args[i];
+    } else if (arg === "-h" || arg === "--help") {
+      showHelp = true;
+    } else if (arg === "-v" || arg === "-V" || arg === "--version") {
+      showVersion = true;
+    } else if (arg.startsWith("-")) {
+      unknownFlag = arg;
+    } else {
+      command = arg;
     }
   }
 
-  return { command, repoDir };
+  return { command, repoDir, showHelp, showVersion, unknownFlag };
 }
 
 async function main(): Promise<void> {
-  const { command, repoDir: explicitRepoDir } = parseArgs();
+  const parsed = parseArgs();
 
-  // Ensure repo is available (clone if needed)
-  const repoDir = await ensureRepo(explicitRepoDir);
-
-  if (command === "setup") {
-    await runSetup(repoDir);
-  } else {
-    console.error(`Unknown command: ${command}`);
-    console.error("Usage: create-x-harness [setup] [--repo-dir <path>]");
+  // Handle --help / --version BEFORE touching the network or filesystem.
+  // Cloning ~/.x-harness or running wrangler auth on `--help` is a setup
+  // side-effect users don't expect.
+  if (parsed.showHelp) {
+    process.stdout.write(HELP_TEXT);
+    return;
+  }
+  if (parsed.showVersion) {
+    console.log(readPackageVersion());
+    return;
+  }
+  if (parsed.unknownFlag) {
+    console.error(`Unknown option: ${parsed.unknownFlag}`);
+    console.error("Run `npx create-x-harness --help` for usage.");
     process.exit(1);
   }
+
+  if (parsed.command !== "setup") {
+    console.error(`Unknown command: ${parsed.command}`);
+    console.error("Run `npx create-x-harness --help` for usage.");
+    process.exit(1);
+  }
+
+  // Ensure repo is available (clone if needed)
+  const repoDir = await ensureRepo(parsed.repoDir);
+  await runSetup(repoDir);
 }
 
 main().catch((error) => {

--- a/packages/create-x-harness/tsconfig.json
+++ b/packages/create-x-harness/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "bundler",
     "esModuleInterop": true,
     "strict": true,
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",
     "declaration": true,

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -2,15 +2,38 @@
   "name": "@x-harness/mcp",
   "version": "0.1.0",
   "license": "MIT",
-  "description": "X Harness MCP Server",
+  "description": "MCP server for X Harness — operate an X (Twitter) account from Claude Code, Cursor, and other AI agents over MCP",
   "type": "module",
   "main": "./dist/index.js",
   "bin": {
     "x-harness-mcp": "./dist/index.js"
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit"
+  },
+  "keywords": [
+    "x",
+    "twitter",
+    "mcp",
+    "model-context-protocol",
+    "claude",
+    "ai-agent"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Shudesu/x-harness-oss.git",
+    "directory": "packages/mcp"
+  },
+  "homepage": "https://github.com/Shudesu/x-harness-oss#readme",
+  "bugs": {
+    "url": "https://github.com/Shudesu/x-harness-oss/issues"
+  },
+  "engines": {
+    "node": ">=20"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
@@ -13,6 +16,19 @@ import { analyticsToolDefs } from './tools/analytics.js';
 import { staffToolDefs } from './tools/staff.js';
 import { campaignToolDefs } from './tools/campaign.js';
 import { usageToolDefs } from './tools/usage.js';
+
+function readPackageVersion(): string {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    // dist/index.js → ../package.json (also resolves when run from src via tsx)
+    const pkg = JSON.parse(
+      readFileSync(join(here, '..', 'package.json'), 'utf-8'),
+    ) as { version?: string };
+    return pkg.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
 
 const API_URL = process.env.X_HARNESS_API_URL ?? 'http://localhost:8787';
 const API_KEY = process.env.X_HARNESS_API_KEY ?? '';
@@ -32,7 +48,7 @@ const allTools = [
   ...usageToolDefs,
 ];
 
-const server = new Server({ name: 'x-harness', version: '0.1.0' }, { capabilities: { tools: {} } });
+const server = new Server({ name: 'x-harness', version: readPackageVersion() }, { capabilities: { tools: {} } });
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: allTools }));
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -19,6 +19,26 @@
     "build": "tsup",
     "typecheck": "tsc --noEmit"
   },
+  "keywords": [
+    "x",
+    "twitter",
+    "crm",
+    "marketing-automation",
+    "sdk",
+    "ai"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Shudesu/x-harness-oss.git",
+    "directory": "packages/sdk"
+  },
+  "homepage": "https://github.com/Shudesu/x-harness-oss#readme",
+  "bugs": {
+    "url": "https://github.com/Shudesu/x-harness-oss/issues"
+  },
+  "engines": {
+    "node": ">=18"
+  },
   "license": "MIT",
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/x-sdk/tsconfig.json
+++ b/packages/x-sdk/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "types": ["@cloudflare/workers-types"],
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
     devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)


### PR DESCRIPTION
## Summary
- Make `create-x-harness --help` / `--version` exit before repo cloning or setup/OAuth side effects
- Add typecheck coverage and Node typings for the create CLI
- Add package metadata for create CLI, SDK, and MCP packages
- Sync MCP runtime version from package.json
- Add missing TypeScript libs/types for SDK and x-sdk typechecks
- Ignore generated local setup/config artifacts

## Verification
- `pnpm install`
- `pnpm --filter create-x-harness build`
- `pnpm --filter create-x-harness typecheck`
- `node packages/create-x-harness/dist/index.js --help`
- `node packages/create-x-harness/dist/index.js --version`
- `node packages/create-x-harness/dist/index.js --bogus` (expected exit 1, no setup side effect)
- `pnpm --filter @x-harness/sdk build`
- `pnpm --filter @x-harness/sdk typecheck`
- `pnpm --filter @x-harness/mcp build`
- `pnpm --filter @x-harness/mcp typecheck`
- `pnpm --filter @x-harness/x-sdk typecheck`
- `pnpm -r build`
- Codex review: no findings

## Notes
Before this change, help/version style invocations could still enter setup paths. A stale `.x-harness-setup.json` generated during audit was removed and the path is now ignored.