### PR TITLE
feat(worker): expose X connector capabilities

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -21,6 +21,7 @@ import { usage } from './routes/usage.js';
 import { xaa } from './routes/xaa.js';
 import { campaigns } from './routes/campaigns.js';
 import { setup } from './routes/setup.js';
+import { capabilities } from './routes/capabilities.js';
 import { processStepSequences } from './services/step-processor.js';
 
 export type Env = {
@@ -60,6 +61,7 @@ app.route('/', usage);
 app.route('/', xaa);
 app.route('/', campaigns);
 app.route('/', setup);
+app.route('/', capabilities);
 
 // Settings API (key-value store)
 app.get('/api/settings', async (c) => {

--- a/apps/worker/src/routes/capabilities.ts
+++ b/apps/worker/src/routes/capabilities.ts
@@ -1,0 +1,51 @@
+import { Hono } from 'hono';
+import type { Env } from '../index.js';
+
+export const HARNESS_VERSION = '0.5.1';
+export const CONNECTOR_VERSION = '2026-05-20';
+
+export const FEATURES = [
+  'engagement-gates',
+  'reply-trigger',
+  'scheduled-posts',
+  'step-sequences',
+  'dm',
+  'campaigns',
+  'line-cross-link',
+  'followers',
+  'tags',
+  'usage',
+  'multi-account',
+  'setup',
+] as const;
+
+export const capabilities = new Hono<Env>();
+
+capabilities.get('/api/capabilities', (c) => {
+  return c.json({
+    success: true,
+    data: {
+      product: 'x-harness',
+      platform: 'x',
+      version: HARNESS_VERSION,
+      connectorVersion: CONNECTOR_VERSION,
+      identity: {
+        primaryKey: 'x_user_id',
+        supportedLinks: ['line_friend_id'],
+      },
+      features: FEATURES,
+      endpoints: {
+        health: '/api/health',
+        staffMe: '/api/staff/me',
+        xAccounts: '/api/x-accounts',
+        engagementGates: '/api/engagement-gates',
+        engagementVerify: '/api/engagement-gates/:id/verify',
+        lineConnections: '/api/line-connections',
+        lineCampaignConfig: '/api/campaigns/line-config',
+        dmConversations: '/api/dm/conversations',
+        campaigns: '/api/campaigns',
+        setupStatus: '/setup',
+      },
+    },
+  });
+});


### PR DESCRIPTION
## Summary
- add /api/capabilities for X Harness unified dashboard discovery
- publish connector metadata, supported identity links, feature flags, and key endpoint paths

## Verification
- pnpm --filter worker typecheck
- git diff --check

Note: pnpm -r typecheck still fails in existing @x-harness/sdk DOM type gaps (RequestInit, AbortSignal, fetch, URLSearchParams).