### PR TITLE
fix(worker/posts): velocity burst guard on immediate-post path (#3233)

### DIFF
--- a/apps/worker/src/routes/posts.ts
+++ b/apps/worker/src/routes/posts.ts
@@ -1,10 +1,19 @@
 import { Hono } from 'hono';
 import { XClient } from '@x-harness/x-sdk';
-import { createScheduledPost, getScheduledPosts, deleteScheduledPost, getXAccountById, getXAccounts, incrementApiUsage, saveQuoteTweets, getQuoteTweetsByAccount, getQuoteTweetsBySource, getLatestDiscoveredAt, recordAction, getActions } from '@x-harness/db';
+import { createScheduledPost, getScheduledPosts, deleteScheduledPost, getXAccountById, getXAccounts, incrementApiUsage, saveQuoteTweets, getQuoteTweetsByAccount, getQuoteTweetsBySource, getLatestDiscoveredAt, recordAction, getActions, recordPostEvent, countRecentPosts } from '@x-harness/db';
 import type { SaveQuoteTweetInput } from '@x-harness/db';
 import type { Env } from '../index.js';
 
 const posts = new Hono<Env>();
+
+// Burst guard (Issue #3233): velocity cap on the immediate-post path. An account
+// may fire at most BURST_MAX immediate posts within BURST_WINDOW_MINUTES. Batch
+// posting must go through POST /api/posts/schedule (with staggered scheduledAt)
+// instead; callers that genuinely need a burst pass { allowBurst: true }. The
+// 2026-06-11 13連発 — 13 immediate posts in minutes — got @shii10000 flagged for
+// spam; this is the physical block so an endpoint mix-up can never burst-fire again.
+const BURST_WINDOW_MINUTES = 10;
+const BURST_MAX = 3;
 
 // Helper: build XClient from account record
 function buildXClient(account: { consumer_key: string | null; consumer_secret: string | null; access_token: string; access_token_secret: string | null }): XClient {
@@ -20,10 +29,28 @@ function buildXClient(account: { consumer_key: string | null; consumer_secret: s
 }
 
 posts.post('/api/posts', async (c) => {
-  const { xAccountId, text, mediaIds, quoteTweetId } = await c.req.json<{ xAccountId: string; text: string; mediaIds?: string[]; quoteTweetId?: string }>();
+  const { xAccountId, text, mediaIds, quoteTweetId, allowBurst } = await c.req.json<{ xAccountId: string; text: string; mediaIds?: string[]; quoteTweetId?: string; allowBurst?: boolean }>();
   if (!text || !xAccountId) return c.json({ success: false, error: 'Missing required fields: xAccountId, text' }, 400);
   const account = await getXAccountById(c.env.DB, xAccountId);
   if (!account) return c.json({ success: false, error: 'X account not found' }, 404);
+
+  // Burst guard (#3233): refuse to fire if this account already posted BURST_MAX
+  // times in the last BURST_WINDOW_MINUTES, unless explicitly overridden. Loud
+  // 429 with error_kind — No Silent Fallback (到達原則 #9).
+  if (allowBurst !== true) {
+    const recent = await countRecentPosts(c.env.DB, account.id, BURST_WINDOW_MINUTES);
+    if (recent >= BURST_MAX) {
+      return c.json(
+        {
+          success: false,
+          error_kind: 'burst_guard',
+          error: `BURST_GUARD: ${recent} posts in the last ${BURST_WINDOW_MINUTES} min reached the limit of ${BURST_MAX}. Use POST /api/posts/schedule for batch posting, or pass { "allowBurst": true } to override intentionally.`,
+        },
+        429,
+      );
+    }
+  }
+
   const xClient = buildXClient(account);
   try {
     const tweet = await xClient.createTweet({
@@ -31,6 +58,9 @@ posts.post('/api/posts', async (c) => {
       media: mediaIds ? { media_ids: mediaIds } : undefined,
       quote_tweet_id: quoteTweetId,
     });
+    // Awaited (not waitUntil) so a sequential posting loop sees this row before
+    // it counts for the next post — that is the burst shape we guard against.
+    await recordPostEvent(c.env.DB, account.id, 'immediate');
     c.executionCtx.waitUntil(incrementApiUsage(c.env.DB, account.id, 'create_tweet'));
     return c.json({ success: true, data: tweet }, 201);
   } catch (err: any) {

--- a/apps/worker/src/services/post-scheduler.ts
+++ b/apps/worker/src/services/post-scheduler.ts
@@ -1,5 +1,5 @@
 import { XClient, XApiRateLimitError } from '@x-harness/x-sdk';
-import { getDueScheduledPosts, updateScheduledPostStatus } from '@x-harness/db';
+import { getDueScheduledPosts, updateScheduledPostStatus, recordPostEvent } from '@x-harness/db';
 
 export async function processScheduledPosts(db: D1Database, xClient: XClient, xAccountId?: string): Promise<void> {
   const allDuePosts = await getDueScheduledPosts(db);
@@ -12,6 +12,9 @@ export async function processScheduledPosts(db: D1Database, xClient: XClient, xA
         media: post.media_ids ? { media_ids: JSON.parse(post.media_ids) } : undefined,
       });
       await updateScheduledPostStatus(db, post.id, 'posted', tweet.id);
+      // Feed the burst-guard velocity window so an immediate post fired right
+      // after a batch of scheduled posts is still counted accurately (#3233).
+      await recordPostEvent(db, post.x_account_id, 'scheduled');
     } catch (err) {
       if (err instanceof XApiRateLimitError) {
         // Transient rate limit — leave post as 'scheduled' so the next cron run retries

--- a/packages/db/migrations/011-post-burst-log.sql
+++ b/packages/db/migrations/011-post-burst-log.sql
@@ -1,0 +1,19 @@
+-- Burst guard: per-post event log for velocity-based rate limiting (Issue #3233)
+--
+-- Records every actual tweet creation with a precise timestamp so the
+-- immediate-post path can count how many posts an account made within a recent
+-- time window and refuse to fire when the velocity exceeds the burst limit.
+--
+-- api_usage_logs is aggregated by (x_account_id, endpoint, date) and therefore
+-- cannot answer "how many posts in the last N minutes" — only "how many today".
+-- The 2026-06-11 13連発 incident (13 distinct posts fired in minutes) is a
+-- velocity signal, not a daily-volume signal, so a dedicated timestamped log is
+-- required. posted_at is a JST ISO string (fixed-width) for lexicographic range
+-- comparison.
+CREATE TABLE IF NOT EXISTS post_burst_log (
+  id TEXT PRIMARY KEY,
+  x_account_id TEXT NOT NULL,
+  posted_at TEXT NOT NULL,
+  kind TEXT NOT NULL DEFAULT 'immediate'
+);
+CREATE INDEX IF NOT EXISTS idx_post_burst_account_time ON post_burst_log (x_account_id, posted_at);

--- a/packages/db/schema.sql
+++ b/packages/db/schema.sql
@@ -121,6 +121,18 @@ CREATE TABLE IF NOT EXISTS scheduled_posts (
 );
 CREATE INDEX IF NOT EXISTS idx_scheduled_posts_status ON scheduled_posts(status);
 
+-- Burst guard: per-post event log for velocity-based rate limiting (Issue #3233).
+-- Records every actual tweet creation so the immediate-post path can count an
+-- account's posting velocity within a recent window. api_usage_logs aggregates
+-- by date and cannot answer "how many posts in the last N minutes".
+CREATE TABLE IF NOT EXISTS post_burst_log (
+  id TEXT PRIMARY KEY,
+  x_account_id TEXT NOT NULL,
+  posted_at TEXT NOT NULL,
+  kind TEXT NOT NULL DEFAULT 'immediate'
+);
+CREATE INDEX IF NOT EXISTS idx_post_burst_account_time ON post_burst_log (x_account_id, posted_at);
+
 CREATE UNIQUE INDEX IF NOT EXISTS idx_deliveries_token ON engagement_gate_deliveries(token);
 
 -- Users (UUID — The Harness unification)

--- a/packages/db/src/__tests__/post-burst.test.ts
+++ b/packages/db/src/__tests__/post-burst.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { recordPostEvent, countRecentPosts } from '../post-burst.js';
+
+// ---------------------------------------------------------------------------
+// Mock D1 — captures the SQL + bound args, returns a canned `.first()` result.
+// ---------------------------------------------------------------------------
+interface Captured {
+  sql: string;
+  args: unknown[];
+}
+
+function mockDb(firstResult: unknown, captured: Captured[]) {
+  return {
+    prepare(sql: string) {
+      return {
+        bind(...args: unknown[]) {
+          captured.push({ sql, args });
+          return {
+            first: async () => firstResult,
+            run: async () => ({ success: true }),
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+// ---------------------------------------------------------------------------
+// recordPostEvent
+// ---------------------------------------------------------------------------
+describe('recordPostEvent', () => {
+  it('inserts one row with account, a JST timestamp, and default kind=immediate', async () => {
+    const captured: Captured[] = [];
+    await recordPostEvent(mockDb(null, captured), 'acc-1');
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].sql).toContain('INSERT INTO post_burst_log');
+    const [id, accountId, postedAt, kind] = captured[0].args as string[];
+    expect(typeof id).toBe('string');
+    expect(accountId).toBe('acc-1');
+    expect(postedAt).toMatch(/\+09:00$/); // JST ISO format
+    expect(kind).toBe('immediate');
+  });
+
+  it('records an explicit kind (scheduled)', async () => {
+    const captured: Captured[] = [];
+    await recordPostEvent(mockDb(null, captured), 'acc-1', 'scheduled');
+    expect((captured[0].args as string[])[3]).toBe('scheduled');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// countRecentPosts
+// ---------------------------------------------------------------------------
+describe('countRecentPosts', () => {
+  it('returns the COUNT and queries by account + a JST cutoff', async () => {
+    const captured: Captured[] = [];
+    const n = await countRecentPosts(mockDb({ n: 5 }, captured), 'acc-1', 10);
+
+    expect(n).toBe(5);
+    expect(captured[0].sql).toContain('COUNT(*)');
+    const [accountId, cutoff] = captured[0].args as string[];
+    expect(accountId).toBe('acc-1');
+    expect(cutoff).toMatch(/\+09:00$/);
+  });
+
+  it('returns 0 when no row is returned', async () => {
+    const n = await countRecentPosts(mockDb(null, []), 'acc-1', 10);
+    expect(n).toBe(0);
+  });
+
+  it('a larger window yields an earlier cutoff (lexicographically before)', async () => {
+    const c10: Captured[] = [];
+    const c60: Captured[] = [];
+    await countRecentPosts(mockDb({ n: 0 }, c10), 'a', 10);
+    await countRecentPosts(mockDb({ n: 0 }, c60), 'a', 60);
+
+    const cutoff10 = (c10[0].args as string[])[1];
+    const cutoff60 = (c60[0].args as string[])[1];
+    // 60-min-ago is earlier in time, and the fixed-width JST ISO format makes
+    // string ordering match chronological ordering.
+    expect(cutoff60 < cutoff10).toBe(true);
+  });
+});

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -11,3 +11,4 @@ export * from './usage.js';
 export * from './follower-snapshots.js';
 export * from './quote-tweets.js';
 export * from './engagement-actions.js';
+export * from './post-burst.js';

--- a/packages/db/src/post-burst.ts
+++ b/packages/db/src/post-burst.ts
@@ -1,0 +1,43 @@
+import { jstNow, toJstString } from './utils.js';
+
+export type PostKind = 'immediate' | 'scheduled';
+
+/**
+ * Record an actual tweet creation so the burst guard can measure posting
+ * velocity. Called after a successful create_tweet. (Issue #3233)
+ *
+ * This must be awaited (not deferred via waitUntil) on the immediate-post path
+ * so that a sequential posting loop — the shape of the 2026-06-11 13連発 — sees
+ * the previous post's row when it counts before firing the next one.
+ */
+export async function recordPostEvent(
+  db: D1Database,
+  xAccountId: string,
+  kind: PostKind = 'immediate',
+): Promise<void> {
+  await db
+    .prepare('INSERT INTO post_burst_log (id, x_account_id, posted_at, kind) VALUES (?, ?, ?, ?)')
+    .bind(crypto.randomUUID(), xAccountId, jstNow(), kind)
+    .run();
+}
+
+/**
+ * Count how many posts the account made within the last `windowMinutes`.
+ *
+ * Uses lexicographic comparison on JST ISO timestamps. jstNow()/toJstString()
+ * emit a fixed-width `YYYY-MM-DDTHH:mm:ss.SSS+09:00` string, so string ordering
+ * matches chronological ordering as long as every row is written with the same
+ * formatter (recordPostEvent is the only writer).
+ */
+export async function countRecentPosts(
+  db: D1Database,
+  xAccountId: string,
+  windowMinutes: number,
+): Promise<number> {
+  const cutoff = toJstString(new Date(Date.now() - windowMinutes * 60_000));
+  const row = await db
+    .prepare('SELECT COUNT(*) as n FROM post_burst_log WHERE x_account_id = ? AND posted_at >= ?')
+    .bind(xAccountId, cutoff)
+    .first<{ n: number }>();
+  return row?.n ?? 0;
+}


### PR DESCRIPTION
## 背景 (実害)
2026-06-11、マー君 (@shii10000) の voice 13本を**予約**するつもりが**即時13連発**。X のスパム検知でアカウントが制限状態に陥り、新アカウント移行の引き金になった。

## 真因 [FACT]
`POST /api/posts` (即時) と `POST /api/posts/schedule` (予約) の2エンドポイントがあり、schedule は対応済みだったが **caller が即時エンドポイントを誤使用**。capability欠落ではなく caller のendpoint取り違え。

## このPR (defense-in-depth L2 = 物理ブロック)
即時pathに **velocity burst guard** を追加。取り違えても物理的に連発不能にする。

- **migration 011 + `post_burst_log`**: 投稿ごとのtimestamp付きログ。`api_usage_logs` は (account, endpoint, **date**) 集計で「直近N分で何本」に答えられないため専用テーブルを新設。
- **`recordPostEvent` / `countRecentPosts`** db helper (JST ISO固定幅の文字列比較で窓判定)。
- **`/api/posts`**: 同一accountが `BURST_WINDOW_MINUTES`(10分) 内に `BURST_MAX`(3) 本以上投稿済みなら **429 loud** (`error_kind: burst_guard`, No Silent Fallback)。意図的バーストは `{ "allowBurst": true }` で明示override。
- `recordPostEvent` は **await**（waitUntilではない）→ 逐次投稿ループ（13連発の形）が次の投稿前に直前行を数えられる。
- scheduler の発火投稿も記録 → velocity窓を honest に保つ。
- db helper の unit test 5件。

## 検証
- `pnpm --filter worker typecheck` / `--filter @x-harness/db typecheck` → pass
- `pnpm exec vitest run` → 29 passed (3 files)
- ※ `packages/sdk` の既存typecheck失敗 (RequestInit/fetch) は本PR範囲外・origin/main から存在。

## 受け入れ条件 (Issue #3233)
- [x] burst guard が N本超を stop し loud に報告 (No Silent Fallback)
- [ ] 13本予約 dry-run で即時発射ゼロ → L1 (caller schedule-by-default, skill層) で対応予定
- [ ] 新X垢デビュー前に本番検証 → deploy は**デビュー直前に子竜ゲート**で別途

## 補足
- defense-in-depth **L1 (caller を schedule-by-default に固定)** は skill層 (x-harness-maestro / marukun-maestro) で続く別変更。
- 本番 `wrangler deploy` は未実施（第一の憲法 Phase E / Issue「今すぐ不要」）。